### PR TITLE
Remove obsolete `filevault` widget

### DIFF
--- a/views/clients.yml
+++ b/views/clients.yml
@@ -2,7 +2,5 @@ row1:
     registered_clients:
 row2:
     client:
-    filevault:
-row3:
     os:
     osbuild:

--- a/views/clients.yml
+++ b/views/clients.yml
@@ -2,5 +2,6 @@ row1:
     registered_clients:
 row2:
     client:
+row3:
     os:
     osbuild:


### PR DESCRIPTION
Widget removed because it was using an inaccurate method to determine FileVault state. Security and filevault_status modules use a better method and contain same widget. 