### PR TITLE
Add tooltip percentage formatter for chart

### DIFF
--- a/views/client_widget.php
+++ b/views/client_widget.php
@@ -50,9 +50,19 @@ $(document).on('appReady', function() {
 			.donut(true)
 			.showLabels(false);
 
+	// tooltip percentage		
+	chart.tooltip.valueFormatter(function (d, i) {
+    	var total = testdata1[0].y + testdata1[1].y;
+    	if (!total) {
+        return d;
+    		}
+    	var percent = ((d / total) * 100).toFixed(1);
+    	return d + " (" + percent + "%)";
+	});
+		
 		chart.title(" ");
 		chart.legend.updateState(false);
-		chart.tooltip.valueFormatter(function(d){return d});
+	//	chart.tooltip.valueFormatter(function(d){return d});
 
 		d3.select("#client-widget svg")
 			.datum(testdata1)


### PR DESCRIPTION
Added a tooltip percentage formatter to display values and their percentages in the chart. Looks like:

<img width="551" height="187" alt="Tool Tip Percent" src="https://github.com/user-attachments/assets/1353dc22-2a2b-4a2d-8bdb-81176735b7d7" />
